### PR TITLE
[#WEB-19142] Adds missing 'main' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@sketchfab/viewer-api",
   "version": "1.9.0",
   "description": "The Sketchfab Viewer API. For browser purposes.",
+  "main": "viewer-api.js",
   "browser": "viewer-api.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Since our module's entry point has a specific name, we need to declare it in the package.json.
The 'browser' field accomplishes this partially but is not meant to work at compile time. However, Typescript type checker runs at compile time and doesn't resolve the browser field. So we need the main field as well.

Should solve https://github.com/sketchfab/viewer-api/issues/1