### PR TITLE
Updated logo URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://static.sketchfab.com/img/press/logos/logo.png" alt="drawing" width="18"/>  Sketchfab Viewer API
+<img src="https://static.sketchfab.com/img/press/logos/sketchfab-logo.png" alt="drawing" width="18"/>  Sketchfab Viewer API
 ---
 
 The Sketchfab Viewer API is a small browser-targeted lib that lets you manipulate the sketchfab viewer inside an embed. 


### PR DESCRIPTION
This is a trivial PR - the URL of the logo seems to have changed since the README was last updated 2 years ago.

It's just a minor visual glitch at the moment when you come to the repo and see the broken image in the README header.